### PR TITLE
Slim down container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:1.22.0-alpine3.19
 
-RUN mkdir -p /app
 WORKDIR /app
 
 COPY go.mod /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN go mod download
 
 COPY . /app
 
-RUN go build -o flow .
+RUN go build -ldflags="-w -s" -o flow
 
 CMD ["sh", "-c", "./flow && while true; do echo 'App is running'; sleep 10; done"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY go.mod /app
 COPY go.sum /app
 
-COPY . /app
-
 RUN go mod download
+
+COPY . /app
 
 RUN go build -o flow .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.0-alpine3.19
+FROM golang:1.22.0-alpine3.19 as builder
 
 WORKDIR /app
 
@@ -10,5 +10,9 @@ RUN go mod download
 COPY . /app
 
 RUN go build -ldflags="-w -s" -o flow
+
+FROM busybox
+
+COPY --from=builder /app/flow /flow
 
 CMD ["sh", "-c", "./flow && while true; do echo 'App is running'; sleep 10; done"]


### PR DESCRIPTION
We can reorder some of the layers to improve cache performance, as well as strip the symbols from the compiled binary, to make the image more efficient. The biggest savings comes from using a multistage build to copy over the binary.